### PR TITLE
解决setQueueRunning无返回数据造成的浏览器JS报错的问题。

### DIFF
--- a/ui/src/app/page/queue-info/queue-info.component.ts
+++ b/ui/src/app/page/queue-info/queue-info.component.ts
@@ -64,7 +64,6 @@ export class QueueInfoComponent implements OnInit, ShouldKeepThisOnNav {
         running: running
       }
     }, res => {
-      this.toasterService.pop(res.success ? "success" : "warning", "Message", res.message);
     });
   }
 


### PR DESCRIPTION
解决setQueueRunning由于服务器无返回数据造成的浏览器JS报错的问题。