### PR TITLE
修改中断某个任务后再无法中断其他任务的BUG

### DIFF
--- a/src/spider/manager/QueueManager.ts
+++ b/src/spider/manager/QueueManager.ts
@@ -1013,7 +1013,7 @@ export class QueueManager {
                         }
                     };
 
-                    appInfo.eventBus.once(Events.QueueManager_InterruptJob, listenInterrupt);
+                    appInfo.eventBus.on(Events.QueueManager_InterruptJob, listenInterrupt);
                     try {
                         const paramArr = [];
 


### PR DESCRIPTION
原代码中`appInfo.eventBus.once(Events.QueueManager_InterruptJob, listenInterrupt);`只会监听`QueueManager_InterruptJob`一次，而一旦发生`QueueManager_InterruptJob`事件，所有此事件的监听程序都会被调用并失效，其结果是再次中断其他任务时，系统无反应。